### PR TITLE
[MEAR-283] Reproducible builds with skinnyWars option

### DIFF
--- a/src/it/basic/verify.bsh
+++ b/src/it/basic/verify.bsh
@@ -18,9 +18,13 @@
  */
 
 import java.io.*;
+import java.nio.file.attribute.FileTime;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.jar.*;
 import java.util.regex.*;
+import java.util.zip.ZipEntry;
 
 File jarFile = new File( basedir, "target/test-1.0.ear" );
 System.out.println( "Checking for existence of " + jarFile );
@@ -35,12 +39,44 @@ String[] includedEntries = {
     "META-INF/application.xml",
     "META-INF/appserver-application.xml",
 };
+
+// Refer to org.apache.maven.archiver.MavenArchiver.parseOutputTimestamp
+DateFormat entryDateFormat = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ssXXX" );
+Date notNormalizedExpectedEntryDate = entryDateFormat.parse( "2020-05-01T12:12:12Z" );
+// Refer to org.codehaus.plexus.archiver.zip.AbstractZipArchiver.normalizeLastModifiedDate
+// and org.codehaus.plexus.archiver.zip.AbstractZipArchiver.dosToJavaTime
+Calendar calendar = Calendar.getInstance();
+FileTime expectedEntryTimestamp = FileTime.fromMillis( notNormalizedExpectedEntryDate.getTime()
+    - calendar.get( Calendar.ZONE_OFFSET ) - calendar.get( Calendar.DST_OFFSET ) );
+
 for ( String included : includedEntries )
 {
     System.out.println( "Checking for existence of " + included );
-    if ( jar.getEntry( included ) == null )
+    ZipEntry jarEntry = jar.getEntry( included );
+    if ( jarEntry == null )
     {
         throw new IllegalStateException( "Missing archive entry: " + included );
+    }
+    FileTime creationTime = jarEntry.getCreationTime();
+    if ( creationTime != null && !creationTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid creation time: " + creationTime
+            + " of archive entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
+    }
+    FileTime lastAccessTime = jarEntry.getLastAccessTime();
+    if ( lastAccessTime != null && !lastAccessTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid last access time: " + lastAccessTime
+            + " of archive entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
+    }
+    FileTime lastModifiedTime = jarEntry.getLastModifiedTime();
+    if ( lastModifiedTime == null || !lastModifiedTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid last modified time: " + lastModifiedTime
+            + " of archive entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
     }
 }
 

--- a/src/it/skinny-wars/ear-module/pom.xml
+++ b/src/it/skinny-wars/ear-module/pom.xml
@@ -27,6 +27,10 @@ under the License.
   <version>1.0</version>
   <packaging>ear</packaging>
 
+  <properties>
+    <project.build.outputTimestamp>2020-05-01T12:12:12Z</project.build.outputTimestamp>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/src/it/skinny-wars/verify.bsh
+++ b/src/it/skinny-wars/verify.bsh
@@ -18,9 +18,13 @@
  */
 
 import java.io.*;
+import java.nio.file.attribute.FileTime;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.jar.*;
 import java.util.regex.*;
+import java.util.zip.ZipEntry;
 
 File jarFile = new File( basedir, "ear-module/target/ear-module-1.0/org.apache.maven.its.ear.skinnywars-war-module-1.0.war" );
 System.out.println( "Checking for existence of " + jarFile );
@@ -35,12 +39,44 @@ String[] includedEntries = {
     "WEB-INF/web.xml",
     "META-INF/MANIFEST.MF"
 };
+
+// Refer to org.apache.maven.archiver.MavenArchiver.parseOutputTimestamp
+DateFormat entryDateFormat = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ssXXX" );
+Date notNormalizedExpectedEntryDate = entryDateFormat.parse( "2020-05-01T12:12:12Z" );
+// Refer to org.codehaus.plexus.archiver.zip.AbstractZipArchiver.normalizeLastModifiedDate
+// and org.codehaus.plexus.archiver.zip.AbstractZipArchiver.dosToJavaTime
+Calendar calendar = Calendar.getInstance();
+FileTime expectedEntryTimestamp = FileTime.fromMillis( notNormalizedExpectedEntryDate.getTime()
+    - calendar.get( Calendar.ZONE_OFFSET ) - calendar.get( Calendar.DST_OFFSET ) );
+
 for ( String included : includedEntries )
 {
     System.out.println( "Checking for included archive entry " + included );
-    if ( jar.getEntry( included ) == null )
+    ZipEntry jarEntry = jar.getEntry( included );
+    if ( jarEntry == null )
     {
-        throw new IllegalStateException( "Missing archive entry: " + included );
+        throw new IllegalStateException( "Missing WAR entry: " + included );
+    }
+    FileTime creationTime = jarEntry.getCreationTime();
+    if ( creationTime != null && !creationTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid creation time: " + creationTime
+            + " of WAR entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
+    }
+    FileTime lastAccessTime = jarEntry.getLastAccessTime();
+    if ( lastAccessTime != null && !lastAccessTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid last access time: " + lastAccessTime
+            + " of WAR entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
+    }
+    FileTime lastModifiedTime = jarEntry.getLastModifiedTime();
+    if ( lastModifiedTime == null || !lastModifiedTime.equals(expectedEntryTimestamp) )
+    {
+        throw new IllegalStateException( "Invalid last modified time: " + lastModifiedTime
+            + " of WAR entry: " + included
+            + ", expected: " + expectedEntryTimestamp );
     }
 }
 

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.zip.ZipException;
 
@@ -285,6 +286,11 @@ public class EarMojo
         super.execute();
 
         zipArchiver.setUseJvmChmod( useJvmChmod );
+        final Date parsedOutputTimestamp = new MavenArchiver().parseOutputTimestamp( outputTimestamp );
+        if ( parsedOutputTimestamp != null )
+        {
+            zipArchiver.configureReproducible( parsedOutputTimestamp );
+        }
         zipUnArchiver.setUseJvmChmod( useJvmChmod );
 
         final JavaEEVersion javaEEVersion = JavaEEVersion.getJavaEEVersion( version );


### PR DESCRIPTION
[MEAR-283](https://issues.apache.org/jira/browse/MEAR-283): timestamp of repackaged EAR modules following same rules / value as timestamp of packaged modules to support reproducible builds when skinnyWar option is turned on

Refer to [that comment](https://issues.apache.org/jira/browse/MEAR-280?focusedCommentId=17179014&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17179014) in [MEAR-280](https://issues.apache.org/jira/browse/MEAR-280) "Reproducible Builds: make entries in output ear files reproducible (order + timestamp)" for details about issue this pull request tries to fix.