### PR TITLE
[MEAR-166] Handling EAR modules of all types when modifying Class-Path and when skinnyWars / skinnyModules is used

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/AbstractEarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/AbstractEarModule.java
@@ -109,7 +109,7 @@ public abstract class AbstractEarModule
      * Class-Path entry depends on libDirectory property of another module and on skinnyWars / skinnyModules parameters
      * of EAR Plugin.
      */
-    protected Boolean classPathItem = Boolean.FALSE;
+    protected boolean classPathItem;
 
     // This is injected once the module has been built.
 

--- a/src/main/java/org/apache/maven/plugins/ear/AbstractEarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/AbstractEarModule.java
@@ -101,6 +101,16 @@ public abstract class AbstractEarModule
      */
     protected String libDirectory;
 
+    /**
+     * If module is considered for inclusion into the Class-Path entry of MANIFEST.mf of other modules. {@code false}
+     * value leads to removal of the module from the Class-Path entry. {@code true} value leads to modification of the
+     * reference to the module in the Class-Path entry if such reference exists or leads to adding of the module into
+     * the Class-Path entry if such reference doesn't exist. Removal, modification or adding of the reference in the
+     * Class-Path entry depends on libDirectory property of another module and on skinnyWars / skinnyModules parameters
+     * of EAR Plugin.
+     */
+    protected Boolean classPathItem = Boolean.FALSE;
+
     // This is injected once the module has been built.
 
     /**
@@ -264,9 +274,15 @@ public abstract class AbstractEarModule
     }
 
     /**
-     * Returns the bundle file name. If null, the artifact's file name is returned.
-     * 
-     * @return the bundle file name
+     * {@inheritDoc}
+     */
+    public boolean isClassPathItem()
+    {
+        return classPathItem;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public String getBundleFileName()
     {
@@ -413,25 +429,6 @@ public abstract class AbstractEarModule
         }
 
         return path;
-    }
-
-    /**
-     * Specify if the objects are both null or both equal.
-     * 
-     * @param first the first object
-     * @param second the second object
-     * @return true if parameters are either both null or equal
-     */
-    static boolean areNullOrEqual( Object first, Object second )
-    {
-        if ( first != null )
-        {
-            return first.equals( second );
-        }
-        else
-        {
-            return second == null;
-        }
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/ear/AbstractEarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/AbstractEarMojo.java
@@ -167,9 +167,9 @@ public abstract class AbstractEarMojo
 
     private List<EarModule> earModules;
 
-    private List<JarModule> allJarModules;
+    private List<EarModule> allEarModules;
 
-    private List<JarModule> providedJarModules;
+    private List<EarModule> providedEarModules;
 
     private JbossConfiguration jbossConfiguration;
 
@@ -272,8 +272,8 @@ public abstract class AbstractEarMojo
 
         // Now we have everything let's built modules which have not been excluded
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_RUNTIME );
-        allJarModules = new ArrayList<JarModule>();
-        providedJarModules = new ArrayList<JarModule>();
+        allEarModules = new ArrayList<EarModule>();
+        providedEarModules = new ArrayList<EarModule>();
         earModules = new ArrayList<EarModule>();
         for ( EarModule earModule : allModules )
         {
@@ -283,18 +283,14 @@ public abstract class AbstractEarMojo
             }
             else
             {
-                boolean isJarModule = earModule instanceof JarModule;
-                if ( isJarModule )
-                {
-                    allJarModules.add( (JarModule) earModule );
-                }
+                allEarModules.add( earModule );
                 if ( filter.include( earModule.getArtifact() ) )
                 {
                     earModules.add( earModule );
                 }
-                else if ( isJarModule )
+                else
                 {
-                    providedJarModules.add( (JarModule) earModule );
+                    providedEarModules.add( earModule );
                 }
             }
         }
@@ -314,27 +310,27 @@ public abstract class AbstractEarMojo
     }
 
     /**
-     * @return The list of {@link #allJarModules}. This corresponds to all JAR modules (compile + runtime).
+     * @return The list of {@link #allEarModules}. This corresponds to all modules (provided + compile + runtime).
      */
-    protected List<JarModule> getAllJarModules()
+    protected List<EarModule> getAllEarModules()
     {
-        if ( allJarModules == null )
+        if ( allEarModules == null )
         {
-            throw new IllegalStateException( "Jar modules have not been initialized" );
+            throw new IllegalStateException( "EAR modules have not been initialized" );
         }
-        return allJarModules;
+        return allEarModules;
     }
 
     /**
-     * @return the list of {@link #providedJarModules}. This corresponds to provided JAR modules.
+     * @return the list of {@link #providedEarModules}. This corresponds to provided modules.
      */
-    protected List<JarModule> getProvidedJarModules()
+    protected List<EarModule> getProvidedEarModules()
     {
-        if ( providedJarModules == null )
+        if ( providedEarModules == null )
         {
             throw new IllegalStateException( "Jar modules have not been initialized" );
         }
-        return providedJarModules;
+        return providedEarModules;
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/ear/AbstractEarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/AbstractEarMojo.java
@@ -272,9 +272,9 @@ public abstract class AbstractEarMojo
 
         // Now we have everything let's built modules which have not been excluded
         ScopeArtifactFilter filter = new ScopeArtifactFilter( Artifact.SCOPE_RUNTIME );
-        allEarModules = new ArrayList<EarModule>();
-        providedEarModules = new ArrayList<EarModule>();
-        earModules = new ArrayList<EarModule>();
+        allEarModules = new ArrayList<>();
+        providedEarModules = new ArrayList<>();
+        earModules = new ArrayList<>();
         for ( EarModule earModule : allModules )
         {
             if ( earModule.isExcluded() )

--- a/src/main/java/org/apache/maven/plugins/ear/EarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarModule.java
@@ -127,8 +127,8 @@ public interface EarModule
     String getBundleFileName();
 
     /**
-     * If module should present in the Class-Path entry of MANIFEST.mf. Doesn't impact Class-Path entry of MANIFEST.mf
-     * of modules which contain all of their dependencies unless skinnyWars / skinnyModules is turned on.
+     * If module should be included into the Class-Path entry of MANIFEST.mf. Doesn't impact Class-Path entry of
+     * MANIFEST.mf of modules which contain all of their dependencies unless skinnyWars / skinnyModules is turned on.
      */
     boolean isClassPathItem();
 

--- a/src/main/java/org/apache/maven/plugins/ear/EarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarModule.java
@@ -119,4 +119,17 @@ public interface EarModule
      */
     String getLibDir();
 
+    /**
+     * Returns the bundle file name. If {@code null}, the artifact's file name is returned.
+     *
+     * @return the bundle file name
+     */
+    String getBundleFileName();
+
+    /**
+     * If module should present in the Class-Path entry of MANIFEST.mf. Doesn't impact Class-Path entry of MANIFEST.mf
+     * of modules which contain all of their dependencies unless skinnyWars / skinnyModules is turned on.
+     */
+    boolean isClassPathItem();
+
 }

--- a/src/main/java/org/apache/maven/plugins/ear/JarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/JarModule.java
@@ -51,6 +51,7 @@ public class JarModule
     public JarModule()
     {
         this.type = DEFAULT_ARTIFACT_TYPE;
+        this.classPathItem = Boolean.TRUE;
     }
 
     /**
@@ -63,7 +64,7 @@ public class JarModule
         super( a );
         setLibBundleDir( defaultLibBundleDir );
         this.includeInApplicationXml = includeInApplicationXml;
-
+        this.classPathItem = Boolean.TRUE;
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/ear/JarModule.java
+++ b/src/main/java/org/apache/maven/plugins/ear/JarModule.java
@@ -51,7 +51,7 @@ public class JarModule
     public JarModule()
     {
         this.type = DEFAULT_ARTIFACT_TYPE;
-        this.classPathItem = Boolean.TRUE;
+        this.classPathItem = true;
     }
 
     /**
@@ -64,7 +64,7 @@ public class JarModule
         super( a );
         setLibBundleDir( defaultLibBundleDir );
         this.includeInApplicationXml = includeInApplicationXml;
-        this.classPathItem = Boolean.TRUE;
+        this.classPathItem = true;
     }
 
     /**

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -65,8 +65,9 @@ ${project.name}
 
 * Version 3.2.0
 
-  {{{./ear-mojo.html#skinnyModules}skinnyModules}} parameter and libDirectory property
-  of EAR modules have been implemented.
+  {{{./ear-mojo.html#skinnyModules}skinnyModules}} parameter, <<<libDirectory>>> property
+  of EAR modules, <<<type>>> property of EAR modules and <<<classPathItem>>> property of
+  EAR modules have been implemented.
 
 * Version 3.0.0
 

--- a/src/site/apt/modules.apt.vm
+++ b/src/site/apt/modules.apt.vm
@@ -141,6 +141,13 @@ EAR Modules
   setting in module <<<MANIFEST.MF>>> is modified and libraries of module located in
   <<<libDirectory>>> and matching libraries of EAR are removed from module.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is true. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
+
 
 * {ejbModule} Properties
 
@@ -179,6 +186,13 @@ EAR Modules
   * <<moduleId>> - sets the id of the module in the generated application.xml.
 
   * <<libDirectory>> - refer to the same name property of {{{ejbClientModule}ejbClientModule}}.
+
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
 
 
 * {jarModule} Properties
@@ -220,6 +234,50 @@ EAR Modules
   * <<includeInApplicationXml>> - set to true to if you want to generate an entry
   of this module in <<<application.xml>>>. Default is false.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is true.
+
+  The module is removed from the <<<Class-Path>>> setting of <<<MANIFEST.MF>>> of another module
+  if the <<<classPathItem>>> property is false and one of the following conditions is met:
+
+    * Another module doesn't contain all of it dependencies (refer to the <<<libDirectory>>>
+    property of particular module type).
+
+    * {{{./ear-mojo.html#skinnyWars}skinnyWars}} parameter is true and another module is
+    a {{{webModule}webModule}}.
+
+    * {{{./ear-mojo.html#skinnyModules}skinnyModules}} parameter is true.
+
+  Existing reference to the module in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of another module is updated to match location of the module in EAR if
+  the <<<classPathItem>>> property is true and one of the following conditions is met:
+
+    * Another module doesn't contain all of it dependencies (refer to the <<<libDirectory>>>
+    property of particular module type).
+
+    * {{{./ear-mojo.html#skinnyWars}skinnyWars}} parameter is true and another module is
+    a {{{webModule}webModule}}.
+
+    * {{{./ear-mojo.html#skinnyModules}skinnyModules}} parameter is true.
+
+  The module is added into the <<<Class-Path>>> setting of another module
+  if the <<<classPathItem>>> is true, there is no existing reference to the module
+  in the <<<Class-Path>>> setting and one of the following conditions is met:
+
+    * {{{./ear-mojo.html#skinnyWars}skinnyWars}} parameter is true, another module is
+    a {{{webModule}webModule}} and one of the following conditions is met:
+
+      * {{{./ear-mojo.html#skipClassPathModification}skipClassPathModification}} parameter is false.
+
+      * {{{./ear-mojo.html#version}version}} parameter is less than 5.
+
+    * {{{./ear-mojo.html#skinnyModules}skinnyModules}} parameter is true and
+    one of the following conditions is met:
+
+      * {{{./ear-mojo.html#skipClassPathModification}skipClassPathModification}} parameter is false.
+
+      * {{{./ear-mojo.html#version}version}} parameter is less than 5.
+
 
 * {parModule} Properties
 
@@ -260,6 +318,13 @@ EAR Modules
   * <<moduleId>> - sets the id of the module in the generated application.xml.
 
   * <<libDirectory>> - refer to the same name property of {{{ejbClientModule}ejbClientModule}}.
+
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
 
 
 * {rarModule} Properties
@@ -303,6 +368,13 @@ EAR Modules
   at the root of archive. Refer to the same name property of
   {{{ejbClientModule}ejbClientModule}} for details.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
+
 
 * {sarModule} Properties
 
@@ -342,6 +414,13 @@ EAR Modules
   * <<libDirectory>> - sets archive directory which contains Java libraries
   packaged into archive. Default is 'lib'. Refer to the same name property of
   {{{ejbClientModule}ejbClientModule}} for details.
+
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
 
 
 * {webModule} Properties
@@ -391,6 +470,13 @@ EAR Modules
   setting in module <<<MANIFEST.MF>>> is modified and libraries of module located in
   <<<libDirectory>>> and matching libraries of EAR are removed from module.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
+
 
 * {wsrModule} Properties
 
@@ -432,6 +518,13 @@ EAR Modules
   packaged into archive. Default is 'lib'. Refer to the same name property of
   {{{ejbClientModule}ejbClientModule}} for details.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
+
 
 * {harModule} Properties
 
@@ -470,6 +563,13 @@ EAR Modules
   packaged into archive. Default is 'lib'. Refer to the same name property of
   {{{ejbClientModule}ejbClientModule}} for details.
 
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
+
 
 * {appClientModule} Properties
 
@@ -506,6 +606,13 @@ EAR Modules
   this module.
 
   * <<moduleId>> - sets the id of the module in the generated application.xml.
+
+  * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
+  of <<<MANIFEST.MF>>> of other modules. Default is false. Refer to the <<<classPathItem>>>
+  property of {{{jarModule}jarModule}} for the cases when the module is removed from
+  the <<<Class-Path>>> setting or added into the <<<Class-Path>>> setting or existing
+  reference to the module is updated in the <<<Class-Path>>> setting of <<<MANIFEST.MF>>>
+  of other modules.
 
 
 * Adding {Custom Artifact Types}

--- a/src/site/apt/modules.apt.vm
+++ b/src/site/apt/modules.apt.vm
@@ -240,7 +240,7 @@ EAR Modules
   The module is removed from the <<<Class-Path>>> setting of <<<MANIFEST.MF>>> of another module
   if the <<<classPathItem>>> property is false and one of the following conditions is met:
 
-    * Another module doesn't contain all of it dependencies (refer to the <<<libDirectory>>>
+    * Another module doesn't contain all of its dependencies (refer to the <<<libDirectory>>>
     property of particular module type).
 
     * {{{./ear-mojo.html#skinnyWars}skinnyWars}} parameter is true and another module is
@@ -252,7 +252,7 @@ EAR Modules
   of another module is updated to match location of the module in EAR if
   the <<<classPathItem>>> property is true and one of the following conditions is met:
 
-    * Another module doesn't contain all of it dependencies (refer to the <<<libDirectory>>>
+    * Another module doesn't contain all of its dependencies (refer to the <<<libDirectory>>>
     property of particular module type).
 
     * {{{./ear-mojo.html#skinnyWars}skinnyWars}} parameter is true and another module is

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -1232,4 +1232,72 @@ public class EarMojoIT
         final boolean[] artifactsDirectory = { false, false, false, false };
         doTestProject( "project-097", "ear", artifacts, artifactsDirectory, null, null, null , true );
     }
+
+    /**
+     * Ensures that when skinnyModules option is turned on then
+     * <ul>
+     * <li>EAR module whose classPathItem property is {@code false} is removed from the Class-Path entry of
+     * MANIFEST.mf of other modules</li>
+     * <li>EAR module whose classPathItem property is {@code true} is added into the Class-Path entry of MANIFEST.mf
+     * or existing reference is updated to match location of the module</li>
+     * <li>EAR module is removed from WARs and RARs (from modules which include their dependencies)</li>
+     * </ul>
+     */
+    public void testProject098()
+        throws Exception
+    {
+        final String projectName = "project-098";
+        final String earModuleName = "ear";
+        final String jarSampleOneLibrary = "jar-sample-one-1.0.jar";
+        final String jarSampleTwoLibrary = "jar-sample-two-1.0.jar";
+        final String jarSampleThreeLibrary = "jar-sample-three-with-deps-1.0.jar";
+        final String ejbFourClientLibrary = "ejb-sample-four-1.0-client.jar";
+        final String jarSampleOneEarLibrary = "lib/eartest-" + jarSampleOneLibrary;
+        final String jarSampleTwoEarLibrary = "lib/eartest-" + jarSampleTwoLibrary;
+        final String jarSampleThreeEarLibrary = "lib/eartest-" + jarSampleThreeLibrary;
+        final String ejbFourClientEarLibrary = "lib/eartest-" + ejbFourClientLibrary;
+        final String ejbThreeLibrary = "ejb-sample-three-1.0.jar";
+        final String ejbFourLibrary = "ejb-sample-four-1.0.jar";
+        final String ejbThreeModule = "eartest-" + ejbThreeLibrary;
+        final String ejbFourModule = "eartest-" + ejbFourLibrary;
+        final String rarLibrary = "rar-sample-one-1.0.rar";
+        final String rarModule = "eartest-" + rarLibrary;
+        final String warModule = "eartest-war-sample-three-1.0.war";
+        final String[] earModules = { ejbThreeModule, ejbFourModule, rarModule, warModule };
+        final boolean[] earModuleDirectory = { false, false, false, false };
+        final String warModuleLibDir = "WEB-INF/lib/";
+        final String rarModuleLibDir = "";
+
+        final File baseDir = doTestProject( projectName, earModuleName,
+            new String[] { ejbThreeModule, ejbFourModule, rarModule, warModule,
+                jarSampleOneEarLibrary, jarSampleTwoEarLibrary, jarSampleThreeEarLibrary, ejbFourClientEarLibrary },
+            new boolean[] { false, false, false, false, false, false, false, false },
+            earModules, earModuleDirectory,
+            new String[][] {
+                { jarSampleThreeEarLibrary, jarSampleTwoEarLibrary, ejbFourClientEarLibrary, jarSampleOneEarLibrary },
+                { jarSampleOneEarLibrary, jarSampleTwoEarLibrary, jarSampleThreeEarLibrary, ejbFourClientEarLibrary },
+                { jarSampleThreeEarLibrary, jarSampleTwoEarLibrary, jarSampleOneEarLibrary, ejbFourClientEarLibrary },
+                { jarSampleOneEarLibrary, jarSampleThreeEarLibrary, jarSampleTwoEarLibrary, ejbFourClientEarLibrary } },
+            true );
+
+        assertEarModulesContent( baseDir, projectName, earModuleName, earModules, earModuleDirectory,
+            new String[][] { null, null, null, { warModuleLibDir } },
+            new String[][] { null, null,
+                {
+                    rarModuleLibDir + jarSampleTwoLibrary,
+                    rarModuleLibDir + jarSampleThreeLibrary,
+                    rarModuleLibDir + ejbFourLibrary,
+                    rarModuleLibDir + ejbFourClientLibrary,
+                },
+                {
+                    warModuleLibDir + jarSampleOneLibrary,
+                    rarModuleLibDir + jarSampleThreeLibrary,
+                    rarModuleLibDir + jarSampleTwoLibrary,
+                    warModuleLibDir + ejbThreeLibrary,
+                    warModuleLibDir + ejbFourLibrary,
+                    warModuleLibDir + ejbFourClientLibrary,
+                    warModuleLibDir + rarLibrary,
+                    warModuleLibDir + rarLibrary
+                } } );
+    }
 }

--- a/src/test/resources/projects/project-098/ear/expected-META-INF/application.xml
+++ b/src/test/resources/projects/project-098/ear/expected-META-INF/application.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<application xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd" version="6">
+  <display-name>maven-ear-plugin-test-project-098</display-name>
+  <module>
+    <ejb>eartest-ejb-sample-three-1.0.jar</ejb>
+  </module>
+  <module>
+    <ejb>eartest-ejb-sample-four-1.0.jar</ejb>
+  </module>
+  <module>
+    <connector>eartest-rar-sample-one-1.0.rar</connector>
+  </module>
+  <module>
+    <web>
+      <web-uri>eartest-war-sample-three-1.0.war</web-uri>
+      <context-root>/war-sample-three</context-root>
+    </web>
+  </module>
+  <library-directory>lib</library-directory>
+</application>

--- a/src/test/resources/projects/project-098/ear/pom.xml
+++ b/src/test/resources/projects/project-098/ear/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ear</groupId>
+    <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+    <version>99.0</version>
+  </parent>
+  <artifactId>maven-ear-plugin-test-project-098</artifactId>
+  <packaging>ear</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.spec.javax.servlet</groupId>
+        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+        <version>${jboss-servlet-api_3.0_spec.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.spec.javax.ejb</groupId>
+        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+        <version>${jboss-ejb-api_3.1_spec.version}</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-one</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-two</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-three-with-deps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-three</artifactId>
+      <type>ejb</type>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-four</artifactId>
+      <type>ejb</type>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>rar-sample-one</artifactId>
+      <type>rar</type>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>war-sample-three</artifactId>
+      <type>war</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <version>6</version>
+          <defaultLibBundleDir>lib</defaultLibBundleDir>
+          <skinnyModules>true</skinnyModules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/ejb-one/pom.xml
+++ b/src/test/resources/projects/project-098/ejb-one/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ear</groupId>
+    <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+    <version>99.0</version>
+  </parent>
+  <groupId>eartest</groupId>
+  <artifactId>ejb-sample-three</artifactId>
+  <version>1.0</version>
+  <packaging>ejb</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-three-with-deps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-four</artifactId>
+      <type>ejb-client</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ejb-plugin</artifactId>
+        <configuration>
+          <ejbVersion>3.1</ejbVersion>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/ejb-one/src/main/java/eartest/Stub.java
+++ b/src/test/resources/projects/project-098/ejb-one/src/main/java/eartest/Stub.java
@@ -1,0 +1,22 @@
+package eartest;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Stub {}

--- a/src/test/resources/projects/project-098/ejb-two/pom.xml
+++ b/src/test/resources/projects/project-098/ejb-two/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ear</groupId>
+    <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+    <version>99.0</version>
+  </parent>
+  <groupId>eartest</groupId>
+  <artifactId>ejb-sample-four</artifactId>
+  <version>1.0</version>
+  <packaging>ejb</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-two</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ejb-plugin</artifactId>
+        <configuration>
+          <ejbVersion>3.1</ejbVersion>
+          <generateClient>true</generateClient>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/ejb-two/src/main/java/eartest/Stub.java
+++ b/src/test/resources/projects/project-098/ejb-two/src/main/java/eartest/Stub.java
@@ -1,0 +1,22 @@
+package eartest;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Stub {}

--- a/src/test/resources/projects/project-098/pom.xml
+++ b/src/test/resources/projects/project-098/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ear</groupId>
+  <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+  <version>99.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>ejb-one</module>
+    <module>ejb-two</module>
+    <module>rar</module>
+    <module>war</module>
+    <module>ear</module>
+  </modules>
+  <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <jboss-servlet-api_3.0_spec.version>1.0.2.Final</jboss-servlet-api_3.0_spec.version>
+    <jboss-ejb-api_3.1_spec.version>1.0.2.Final</jboss-ejb-api_3.1_spec.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.spec.javax.servlet</groupId>
+        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+        <version>${jboss-servlet-api_3.0_spec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.spec.javax.ejb</groupId>
+        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+        <version>${jboss-ejb-api_3.1_spec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>jar-sample-one</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>jar-sample-two</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>jar-sample-three-with-deps</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>ejb-sample-three</artifactId>
+        <version>1.0</version>
+        <type>ejb</type>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>ejb-sample-four</artifactId>
+        <version>1.0</version>
+        <type>ejb</type>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>ejb-sample-four</artifactId>
+        <version>1.0</version>
+        <type>ejb-client</type>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>rar-sample-one</artifactId>
+        <version>1.0</version>
+        <type>rar</type>
+      </dependency>
+      <dependency>
+        <groupId>eartest</groupId>
+        <artifactId>war-sample-three</artifactId>
+        <version>1.0</version>
+        <type>war</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@mavenCompilerPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-ejb-plugin</artifactId>
+          <version>@mavenEjbPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-rar-plugin</artifactId>
+          <version>@mavenRarPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>@mavenWarPluginVersion@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/rar/pom.xml
+++ b/src/test/resources/projects/project-098/rar/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ear</groupId>
+    <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+    <version>99.0</version>
+  </parent>
+  <groupId>eartest</groupId>
+  <artifactId>rar-sample-one</artifactId>
+  <version>1.0</version>
+  <packaging>rar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-three-with-deps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-four</artifactId>
+      <type>ejb</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-rar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/rar/src/main/rar/META-INF/ra.xml
+++ b/src/test/resources/projects/project-098/rar/src/main/rar/META-INF/ra.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<connector>
+  <fake-content></fake-content>
+</connector>

--- a/src/test/resources/projects/project-098/rar/src/main/rar/SomeResource.txt
+++ b/src/test/resources/projects/project-098/rar/src/main/rar/SomeResource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/test/resources/projects/project-098/war/pom.xml
+++ b/src/test/resources/projects/project-098/war/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ear</groupId>
+    <artifactId>maven-ear-plugin-test-project-098-parent</artifactId>
+    <version>99.0</version>
+  </parent>
+  <groupId>eartest</groupId>
+  <artifactId>war-sample-three</artifactId>
+  <version>1.0</version>
+  <packaging>war</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>jar-sample-one</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-three</artifactId>
+      <type>ejb</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/project-098/war/src/main/webapp/WEB-INF/web.xml
+++ b/src/test/resources/projects/project-098/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+</web-app>


### PR DESCRIPTION
[MEAR-166] - Removing EAR modules of all types when skinnyWars / skinnyModules is on. Updating reference to the EAR modules of all types in the Class-Path entry of MANIFEST.mf when modifying that entry.
