### PR TITLE
[MEAR-304] Update plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,11 +264,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.1</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -80,22 +80,22 @@
   </contributors>
 
   <properties>
-    <mavenArchiverVersion>3.5.1</mavenArchiverVersion>
+    <mavenArchiverVersion>3.5.2</mavenArchiverVersion>
     <mavenFilteringVersion>3.2.0</mavenFilteringVersion>
-    <mavenVersion>3.1.1</mavenVersion>
+    <mavenVersion>3.2.5</mavenVersion>
     <javaVersion>7</javaVersion>
-    <surefire.version>2.22.2</surefire.version>
-    <mavenWarPluginVersion>3.3.1</mavenWarPluginVersion>
-    <mavenCompilerPluginVersion>2.5.1</mavenCompilerPluginVersion>
+    <surefire.version>3.0.0-M6</surefire.version>
+    <mavenWarPluginVersion>3.3.2</mavenWarPluginVersion>
+    <mavenCompilerPluginVersion>3.10.1</mavenCompilerPluginVersion>
     <mavenEjbPluginVersion>3.1.0</mavenEjbPluginVersion>
     <mavenRarPluginVersion>2.4</mavenRarPluginVersion>
-    <mavenJarPluginVersion>3.2.0</mavenJarPluginVersion>
+    <mavenJarPluginVersion>3.2.2</mavenJarPluginVersion>
     <jbossPackagingPluginVersion>2.2</jbossPackagingPluginVersion>
     <invoker.skip>false</invoker.skip>
     <invoker.install.skip>${invoker.skip}</invoker.install.skip>
     <invoker.it.skip>${invoker.skip}</invoker.it.skip>
     <invoker.cloneClean>true</invoker.cloneClean>
-    <mavenPluginToolsVersion>3.6.0</mavenPluginToolsVersion><!-- required for Java 11 generated Mojo -->
+    <mavenPluginToolsVersion>3.6.4</mavenPluginToolsVersion><!-- required for Java 11 generated Mojo -->
     <checkstyle.violation.ignore>ParameterNumber,MethodLength</checkstyle.violation.ignore>
     <project.build.outputTimestamp>2020-12-30T10:47:20Z</project.build.outputTimestamp>
   </properties>
@@ -121,6 +121,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
       <version>${mavenArchiverVersion}</version>
     </dependency>
@@ -132,7 +144,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.2.5</version>
+      <version>4.2.7</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,16 +105,19 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -129,7 +132,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.2.4</version>
+      <version>4.2.5</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -159,7 +162,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
-      <version>3.3.3</version>
+      <version>3.3.4</version>
     </dependency>
 
     <dependency>
@@ -257,12 +260,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -272,6 +275,18 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
Set maven bits to proper scope, update
deps and fix parent enforcer that still
want to use maven2 bits.

---

https://issues.apache.org/jira/browse/MEAR-304