### PR TITLE
[MEAR-302] Support JakartaEE 9 schema

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/ApplicationXmlWriter.java
+++ b/src/main/java/org/apache/maven/plugins/ear/ApplicationXmlWriter.java
@@ -82,6 +82,10 @@ final class ApplicationXmlWriter
             {
                 writer = initializeRootElementEight( w );
             }
+            else if ( JavaEEVersion.NINE.eq( version ) )
+            {
+                writer = initializeRootElementNine( w );
+            }
     
             // writer is still on root element, so we can still add this attribute
             if ( context.getApplicationId() != null )
@@ -268,6 +272,18 @@ final class ApplicationXmlWriter
         writer.addAttribute( "xsi:schemaLocation",
             "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd" );
         writer.addAttribute( "version", "8" );
+        return writer;
+    }
+
+    private XMLWriter initializeRootElementNine( Writer w )
+    {
+        XMLWriter writer = initializeXmlWriter( w, null );
+        writer.startElement( APPLICATION_ELEMENT );
+        writer.addAttribute( "xmlns", "https://jakarta.ee/xml/ns/jakartaee" );
+        writer.addAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
+        writer.addAttribute( "xsi:schemaLocation",
+            "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd" );
+        writer.addAttribute( "version", "9" );
         return writer;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/ear/util/JavaEEVersion.java
+++ b/src/main/java/org/apache/maven/plugins/ear/util/JavaEEVersion.java
@@ -43,6 +43,8 @@ public class JavaEEVersion
     
     private static final String VERSION_8 = "8";
 
+    private static final String VERSION_9 = "9";
+
     private static final Map<String, JavaEEVersion> VERSION_MAP = new HashMap<String, JavaEEVersion>();
 
     /**
@@ -74,6 +76,11 @@ public class JavaEEVersion
      * Represents the JavaEE 8 version.
      */
     public static final JavaEEVersion EIGHT = new JavaEEVersion( Integer.valueOf( 5 ), VERSION_8 );
+
+    /**
+     * Represents the JakartaEE 9 version.
+     */
+    public static final JavaEEVersion NINE = new JavaEEVersion( Integer.valueOf( 6 ), VERSION_9 );
 
     private final Integer index;
 
@@ -184,7 +191,8 @@ public class JavaEEVersion
             || VERSION_5.equals( paramVersion ) 
             || VERSION_6.equals( paramVersion ) 
             || VERSION_7.equals( paramVersion )
-            || VERSION_8.equals( paramVersion );
+            || VERSION_8.equals( paramVersion )
+            || VERSION_9.equals( paramVersion );
         // @formatter:on
     }
 

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -1300,4 +1300,13 @@ public class EarMojoIT
                     warModuleLibDir + rarLibrary
                 } } );
     }
+
+    /**
+     * Builds an EAR with deployment descriptor configuration for JakartaEE 9.
+     */
+    public void testProject099()
+            throws Exception
+    {
+        doTestProject( "project-099", new String[] { "eartest-ejb-sample-one-1.0.jar" } );
+    }
 }

--- a/src/test/resources/projects/project-099/expected-META-INF/application.xml
+++ b/src/test/resources/projects/project-099/expected-META-INF/application.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_9.xsd" version="9">
+  <display-name>maven-ear-plugin-test-project-099</display-name>
+  <module>
+    <ejb>eartest-ejb-sample-one-1.0.jar</ejb>
+  </module>
+</application>
+

--- a/src/test/resources/projects/project-099/pom.xml
+++ b/src/test/resources/projects/project-099/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ear</groupId>
+  <artifactId>maven-ear-plugin-test-project-099</artifactId>
+  <version>99.0</version>
+  <name>Maven</name>
+  <packaging>ear</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-one</artifactId>
+      <version>1.0</version>
+      <type>ejb</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <version>9</version>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Locally:
```
[INFO] Tests run: 98, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 502.266 s - in org.apache.maven.plugins.ear.it.EarMojoIT
```