### PR TITLE
Bump filtering from 3.2.0 to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
   <properties>
     <mavenArchiverVersion>3.5.1</mavenArchiverVersion>
-    <mavenFilteringVersion>3.2.0</mavenFilteringVersion>
+    <mavenFilteringVersion>3.3.0</mavenFilteringVersion>
     <mavenVersion>3.1.1</mavenVersion>
     <javaVersion>8</javaVersion>
     <mavenWarPluginVersion>3.3.1</mavenWarPluginVersion>

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -55,6 +55,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.ear.util.EarMavenArchiver;
 import org.apache.maven.plugins.ear.util.JavaEEVersion;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.shared.filtering.FilterWrapper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
@@ -303,7 +304,7 @@ public class EarMojo
     @Parameter( defaultValue = "${session}", readonly = true, required = true )
     private MavenSession session;
 
-    private List<FileUtils.FilterWrapper> filterWrappers;
+    private List<FilterWrapper> filterWrappers;
 
     /**
      * @since 2.9
@@ -743,7 +744,7 @@ public class EarMojo
         return !mavenResourcesFiltering.filteredFileExtension( fileName, nonFilteredFileExtensions );
     }
 
-    private List<FileUtils.FilterWrapper> getFilterWrappers()
+    private List<FilterWrapper> getFilterWrappers()
         throws MojoExecutionException
     {
         if ( filterWrappers == null )


### PR DESCRIPTION
This replaces
- https://github.com/apache/maven-ear-plugin/pull/65

with API changes included.

Needed this one as well:
- https://github.com/apache/maven-ear-plugin/pull/67