### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -562,7 +562,7 @@ public class EarMojo
      */
     public String[] getPackagingExcludes()
     {
-        if ( StringUtils.isEmpty( packagingExcludes ) )
+        if ( packagingExcludes == null || packagingExcludes.isEmpty() )
         {
             return new String[0];
         }
@@ -585,7 +585,7 @@ public class EarMojo
      */
     public String[] getPackagingIncludes()
     {
-        if ( StringUtils.isEmpty( packagingIncludes ) )
+        if ( packagingIncludes == null || packagingIncludes.isEmpty() )
         {
             return new String[] { "**" };
         }

--- a/src/main/java/org/apache/maven/plugins/ear/EjbRef.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EjbRef.java
@@ -19,7 +19,6 @@ package org.apache.maven.plugins.ear;
  * under the License.
  */
 
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XMLWriter;
 
 /**
@@ -56,11 +55,11 @@ public class EjbRef
      */
     public EjbRef( String description, String name, String type, String lookupName )
     {
-        if ( StringUtils.isEmpty( name ) )
+        if ( name == null || name.isEmpty() )
         {
             throw new IllegalArgumentException( EJB_NAME + " in " + EJB_REF + " element cannot be null." );
         }
-        else if ( StringUtils.isEmpty( type ) && StringUtils.isEmpty( lookupName ) )
+        else if ( (type == null || type.isEmpty()) && (lookupName == null || lookupName.isEmpty()) )
         {
             throw new IllegalArgumentException( EJB_TYPE + " in " + EJB_REF + " element cannot be null if no "
                 + EJB_LOOKUP_NAME + " was specified." );

--- a/src/main/java/org/apache/maven/plugins/ear/EnvEntry.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EnvEntry.java
@@ -19,7 +19,6 @@ package org.apache.maven.plugins.ear;
  * under the License.
  */
 
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XMLWriter;
 
 /**
@@ -54,11 +53,11 @@ class EnvEntry
 
     EnvEntry( String description, String name, String type, String value, String lookupName )
     {
-        if ( StringUtils.isEmpty( name ) )
+        if ( name == null || name.isEmpty() )
         {
             throw new IllegalArgumentException( ENV_ENTRY_NAME + " in " + ENV_ENTRY + " element cannot be null." );
         }
-        else if ( StringUtils.isEmpty( type ) && StringUtils.isEmpty( value ) )
+        else if ( (type == null || type.isEmpty()) && (value == null || value.isEmpty()) )
         {
             throw new IllegalArgumentException( ENV_ENTRY_TYPE + " in " + ENV_ENTRY + " element cannot be null if no "
                 + ENV_ENTRY_VALUE + " was specified." );

--- a/src/main/java/org/apache/maven/plugins/ear/ResourceRef.java
+++ b/src/main/java/org/apache/maven/plugins/ear/ResourceRef.java
@@ -19,7 +19,6 @@ package org.apache.maven.plugins.ear;
  * under the License.
  */
 
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XMLWriter;
 
 /**
@@ -72,12 +71,12 @@ public class ResourceRef
      */
    public ResourceRef( String name, String type, String auth, String lookupName )
     {
-        if ( StringUtils.isEmpty( name ) )
+        if ( name == null || name.isEmpty() )
         {
             throw new IllegalArgumentException( RESOURCE_REF_NAME + " in " + RESOURCE_REF_NAME
                 + " element cannot be null." );
         }
-        else if ( StringUtils.isEmpty( type ) && StringUtils.isEmpty( auth ) )
+        else if ( (type == null || type.isEmpty()) && (auth == null || auth.isEmpty()) )
         {
             throw new IllegalArgumentException( RESOURCE_TYPE + " in " + RESOURCE_REF_NAME
                 + " element cannot be null " );


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu