### PR TITLE
Drop unnecessary `System.out` usage

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/EnvEntry.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EnvEntry.java
@@ -91,7 +91,6 @@ class EnvEntry {
      * @param writer the writer to use
      */
     public void appendEnvEntry(XMLWriter writer) {
-        System.out.println("appendEnvEntry()");
         writer.startElement(ENV_ENTRY);
 
         // description


### PR DESCRIPTION
I'm seeing this:
```
[INFO] --- ear:3.3.0:generate-application-xml (default-generate-application-xml) @ ... ---
[INFO] Generating application.xml
appendEnvEntry()
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ ... ---
```

And I don't want to.

-----


- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
