### PR TITLE
Fix skinny-wars-timestamp IT under Maven 4 (settings.xml RRF id collision)

### DIFF
--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -28,7 +28,7 @@ under the License.
       </activation>
       <repositories>
         <repository>
-          <id>local.central</id>
+          <id>local.it</id>
           <url>@localRepositoryUrl@</url>
           <releases>
             <enabled>true</enabled>
@@ -50,7 +50,7 @@ under the License.
       </repositories>
       <pluginRepositories>
         <pluginRepository>
-          <id>local.central</id>
+          <id>local.it</id>
           <url>@localRepositoryUrl@</url>
           <releases>
             <enabled>true</enabled>


### PR DESCRIPTION
## Summary

The `skinny-wars-timestamp` integration test is the single IT failing under Maven 4.0.0-rc-5 (and against `apache/maven` master snapshot) on master, which leaves PR #499 ("enable build with Maven 4") with a red `macos-latest jdk-21` rc-5 lane and cancelled siblings. This PR fixes the IT fixture so the rc-5 matrix turns green.

## Root cause

Maven 4 (via Maven Resolver 2's Remote Repository Filter) ships an auto-discovered "central" prefix list and applies it to any repository whose `<id>` is exactly `central`. The IT's `src/it/settings.xml` declares both a `<repository>` and a `<pluginRepository>` with `<id>local.central</id>` — the *exact id collides* with the prefix-filter machinery. The result: when the IT installs the test artifact `eartest:jar-sample-one` into the local IT repository, the nested Maven build tries to resolve it from `local.central` and the RRF rejects the lookup with:

```
ArtifactFilteredOutException: Path eartest/jar-sample-one/... NOT allowed from central
```

The bug is entirely in the IT fixture; the production `MavenEarPlugin` is unaffected. Background context exists in #478 (cstamas confirmed the RRF diagnosis).

## Fix

Rename both `<id>local.central</id>` occurrences in `src/it/settings.xml` to `<id>local.it</id>`. Two lines changed.

## Verification

- `mvn -P run-its verify` against Maven `4.0.0-rc-5` (sdkman, JDK 17.0.18 Temurin / macOS aarch64): **Passed: 18, Failed: 0, Errors: 0, Skipped: 0**.
- Before the fix the same invocation reproduces the `Path ... NOT allowed from central` error PR #499's CI shows.

## Context

- Unblocks #499 (CI matrix flip to `maven4-enabled: true`).
- Independent of any Maven Resolver RRF semantics changes — this is the IT fixture being too "central"-like in its `<id>`.
- No production code change; no POM/dependency bump.

cc @Bukama @cstamas
