### PR TITLE
Fix sar-sample-two and skinny-wars-timestamp ITs on Maven 4 rc-5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <mavenEjbPluginVersion>3.2.1</mavenEjbPluginVersion>
     <mavenRarPluginVersion>3.0.0</mavenRarPluginVersion>
     <mavenJarPluginVersion>${version.maven-jar-plugin}</mavenJarPluginVersion>
+    <mavenResourcesPluginVersion>${version.maven-resources-plugin}</mavenResourcesPluginVersion>
     <jbossPackagingPluginVersion>2.2</jbossPackagingPluginVersion>
 
     <invoker.skip>false</invoker.skip>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -32,9 +32,11 @@ under the License.
           <url>@localRepositoryUrl@</url>
           <releases>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </snapshots>
         </repository>
         <repository>
@@ -42,9 +44,11 @@ under the License.
           <url>file://@localSnapshotRepositoryPath@</url>
           <releases>
             <enabled>false</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </snapshots>
         </repository>
       </repositories>
@@ -54,9 +58,11 @@ under the License.
           <url>@localRepositoryUrl@</url>
           <releases>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/src/test/resources/projects/project-092/pom.xml
+++ b/src/test/resources/projects/project-092/pom.xml
@@ -103,6 +103,11 @@ under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>@mavenResourcesPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>@mavenWarPluginVersion@</version>
         </plugin>

--- a/src/test/resources/projects/project-093/pom.xml
+++ b/src/test/resources/projects/project-093/pom.xml
@@ -84,6 +84,11 @@ under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>@mavenResourcesPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>@mavenWarPluginVersion@</version>
         </plugin>

--- a/src/test/resources/projects/project-094/pom.xml
+++ b/src/test/resources/projects/project-094/pom.xml
@@ -96,6 +96,11 @@ under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>@mavenResourcesPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>@mavenWarPluginVersion@</version>
         </plugin>

--- a/src/test/resources/projects/project-097/pom.xml
+++ b/src/test/resources/projects/project-097/pom.xml
@@ -69,6 +69,11 @@ under the License.
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>@mavenResourcesPluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>@mavenWarPluginVersion@</version>
         </plugin>


### PR DESCRIPTION
## Summary

Two integration tests fail on Maven 4.0.0-rc-5 in PR #499's matrix. This PR
makes them pass with conservative IT-fixture changes only — no production
code touched.

## Failure A — `skinny-wars-timestamp` (invoker IT)

The fixture `src/test/resources/m2snapshots/.../maven-metadata.xml` has no
`.sha1` / `.md5` companions. On Maven 4 / Resolver 2.0.13 this trips
`ChecksumFailureException` for the metadata transfer from the IT's `file://`
`local.snapshot` repo; the snapshot version then cannot be resolved and the
build aborts with `Missing file: war-module-one-1.0.war`.

**Fix**: add `<checksumPolicy>ignore</checksumPolicy>` to all `<releases>` /
`<snapshots>` blocks in `src/it/settings.xml`. This is the long-standing
Apache-plugin-IT convention for `file://` fixtures (the same line is present
in `maven-clean-plugin`, `maven-compiler-plugin`, `maven-deploy-plugin`,
`maven-install-plugin`, `maven-resources-plugin`, `maven-shade-plugin`,
`maven-site-plugin`, and others).

This is a workaround at the IT-fixture layer. The underlying Resolver
behavior is tracked at apache/maven-resolver#1920 (labeled `bug`, milestone
2.0.19), so this PR should become unnecessary once Maven 4 picks up that
Resolver release.

## Failure B — `EarMojoIT.sar-sample-two` (failsafe Java IT)

Maven 4 rc-5 picks the baked-in default `maven-resources-plugin:4.0.0-beta-1`
for the test-project `default-resources` goal, which raises
`NoSuchMethodError` against the current `org.apache.maven.api` shape. Local
caches with a 3.x version of the plugin silently mask the failure via Maven
4's "compatibility-failed → look for compatible RELEASE" fallback; pristine
CI environments hit it directly.

**Fix**: pin `maven-resources-plugin` via the existing `@-token`
`pluginManagement` pattern in `project-092` / `-093` / `-094` / `-097`, with
a new `<mavenResourcesPluginVersion>` property sourced from `apache-parent`'s
`version.maven-resources-plugin`. Mirrors what landed for
`maven-source-plugin` in apache/maven-javadoc-plugin#1332.

## Verification

Validated end-to-end on the fork branch
`aschemaven/maven-ear-plugin#mvn4-pr499-fail-at-end`, which combines
Bukama's #499 (`maven4-enabled: true`) with this PR's two fixes and
`verify-fail-fast: false` for full matrix visibility:

| CI run | Commit                                    | rc-5 result |
|---|---|---|
| [27273896660](https://github.com/aschemaven/maven-ear-plugin/actions/runs/27273896660) | no fixes                                  | 6/6 red |
| [27279805280](https://github.com/aschemaven/maven-ear-plugin/actions/runs/27279805280) | Fix B (resources-plugin pin) only         | 6/6 red — only `skinny-wars-timestamp` chain left |
| [27283681337](https://github.com/aschemaven/maven-ear-plugin/actions/runs/27283681337) | Fix A + Fix B (this PR's content)         | **6/6 green** |

This PR's own CI on `mvn4-rc5-it-fixes` only exercises Maven 3.9.16 because
`maven4-enabled` defaults to `false` on `master`. **@Bukama** — once #499
merges, please rebase this PR so the upstream matrix surfaces Maven 4 here
directly.

## Related

- #499 (@Bukama) — CI flag flip that surfaces the failures. Recommend
  merging #499 first, then rebasing here.
- #478 (@cstamas's 2026-01 diagnosis pointed correctly at the Resolver area;
  the mechanism documented above is the refined understanding).
- apache/maven-javadoc-plugin#1332 — sibling Maven-4-API-pin fix for
  `maven-source-plugin:4.0.0-beta-1`.
- apache/maven-resolver#1920 — Resolver bug tracking the underlying behavior
  (milestone 2.0.19).

cc @Bukama @cstamas @hboutemy