### PR TITLE
fix: inline constants in error messages in ResourceRef constructor

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/ResourceRef.java
+++ b/src/main/java/org/apache/maven/plugins/ear/ResourceRef.java
@@ -69,10 +69,9 @@ public class ResourceRef {
      */
     public ResourceRef(String name, String type, String auth, String lookupName) {
         if (name == null || name.isEmpty()) {
-            throw new IllegalArgumentException(
-                    RESOURCE_REF_NAME + " in " + RESOURCE_REF_NAME + " element cannot be null.");
+            throw new IllegalArgumentException("res-ref-name in resource-ref element cannot be null.");
         } else if ((type == null || type.isEmpty()) && (auth == null || auth.isEmpty())) {
-            throw new IllegalArgumentException(RESOURCE_TYPE + " in " + RESOURCE_REF_NAME + " element cannot be null ");
+            throw new IllegalArgumentException("res-type in resource-ref element cannot be null");
         }
 
         this.name = name;


### PR DESCRIPTION
Fixes #520

Inlined the named constants in the error messages in `ResourceRef` constructor with the correct string literals. The previous messages used `RESOURCE_REF_NAME` ("res-ref-name") for the element name where they should have used `RESOURCE_REF` ("resource-ref").