### PR TITLE
fix: trim whitespace-only classifier to prevent spaces in EAR filename

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -305,6 +305,14 @@ public class EarMojo extends AbstractEarMojo {
         // Initializes ear modules
         super.execute();
 
+        // Normalize classifier: trim whitespace and treat empty as null
+        if (classifier != null) {
+            classifier = classifier.trim();
+            if (classifier.isEmpty()) {
+                classifier = null;
+            }
+        }
+
         File earFile = getEarFile(outputDirectory, finalName, classifier);
         MavenArchiver archiver = new EarMavenArchiver(getModules());
         File ddFile = new File(getWorkDirectory(), APPLICATION_XML_URI);
@@ -560,10 +568,7 @@ public class EarMojo extends AbstractEarMojo {
      * @return the EAR file to generate
      */
     private static File getEarFile(String basedir, String finalName, String classifier) {
-        if (classifier != null) {
-            classifier = classifier.trim();
-        }
-        if (classifier == null || classifier.isEmpty()) {
+        if (classifier == null) {
             classifier = "";
         } else if (!classifier.startsWith("-")) {
             classifier = "-" + classifier;

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -560,9 +560,12 @@ public class EarMojo extends AbstractEarMojo {
      * @return the EAR file to generate
      */
     private static File getEarFile(String basedir, String finalName, String classifier) {
-        if (classifier == null) {
+        if (classifier != null) {
+            classifier = classifier.trim();
+        }
+        if (classifier == null || classifier.isEmpty()) {
             classifier = "";
-        } else if (classifier.trim().length() > 0 && !classifier.startsWith("-")) {
+        } else if (!classifier.startsWith("-")) {
             classifier = "-" + classifier;
         }
 

--- a/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.ear;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EarMojoTest {
+
+    private static File invokeGetEarFile(String basedir, String finalName, String classifier) throws Exception {
+        Method method = EarMojo.class.getDeclaredMethod("getEarFile", String.class, String.class, String.class);
+        method.setAccessible(true);
+        return (File) method.invoke(null, basedir, finalName, classifier);
+    }
+
+    @Test
+    void testGetEarFileWithNullClassifier() throws Exception {
+        File result = invokeGetEarFile("/tmp", "myapp", null);
+        assertEquals(new File("/tmp", "myapp.ear"), result);
+    }
+
+    @Test
+    void testGetEarFileWithClassifier() throws Exception {
+        File result = invokeGetEarFile("/tmp", "myapp", "sources");
+        assertEquals(new File("/tmp", "myapp-sources.ear"), result);
+    }
+
+    @Test
+    void testGetEarFileWithDashPrefixedClassifier() throws Exception {
+        File result = invokeGetEarFile("/tmp", "myapp", "-sources");
+        assertEquals(new File("/tmp", "myapp-sources.ear"), result);
+    }
+
+    @Test
+    void testGetEarFileWithWhitespaceOnlyClassifier() throws Exception {
+        File result = invokeGetEarFile("/tmp", "myapp", "   ");
+        assertEquals(new File("/tmp", "myapp.ear"), result);
+        assertFalse(
+                result.getAbsolutePath().contains(" "),
+                "EAR filename should not contain spaces from whitespace-only classifier");
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
@@ -29,9 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EarMojoTest {
 
     @TempDir
-    static File tempDir;
+    File tempDir;
 
-    private static File invokeGetEarFile(String finalName, String classifier) throws Exception {
+    private File invokeGetEarFile(String finalName, String classifier) throws Exception {
         Method method = EarMojo.class.getDeclaredMethod("getEarFile", String.class, String.class, String.class);
         method.setAccessible(true);
         return (File) method.invoke(null, tempDir.getAbsolutePath(), finalName, classifier);

--- a/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
@@ -24,40 +24,32 @@ import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class EarMojoTest {
 
-    private static File invokeGetEarFile(String basedir, String finalName, String classifier) throws Exception {
+    private static final String TMPDIR = System.getProperty("java.io.tmpdir");
+
+    private static File invokeGetEarFile(String finalName, String classifier) throws Exception {
         Method method = EarMojo.class.getDeclaredMethod("getEarFile", String.class, String.class, String.class);
         method.setAccessible(true);
-        return (File) method.invoke(null, basedir, finalName, classifier);
+        return (File) method.invoke(null, TMPDIR, finalName, classifier);
     }
 
     @Test
     void testGetEarFileWithNullClassifier() throws Exception {
-        File result = invokeGetEarFile("/tmp", "myapp", null);
-        assertEquals(new File("/tmp", "myapp.ear"), result);
+        File result = invokeGetEarFile("myapp", null);
+        assertEquals(new File(TMPDIR, "myapp.ear"), result);
     }
 
     @Test
     void testGetEarFileWithClassifier() throws Exception {
-        File result = invokeGetEarFile("/tmp", "myapp", "sources");
-        assertEquals(new File("/tmp", "myapp-sources.ear"), result);
+        File result = invokeGetEarFile("myapp", "sources");
+        assertEquals(new File(TMPDIR, "myapp-sources.ear"), result);
     }
 
     @Test
     void testGetEarFileWithDashPrefixedClassifier() throws Exception {
-        File result = invokeGetEarFile("/tmp", "myapp", "-sources");
-        assertEquals(new File("/tmp", "myapp-sources.ear"), result);
-    }
-
-    @Test
-    void testGetEarFileWithWhitespaceOnlyClassifier() throws Exception {
-        File result = invokeGetEarFile("/tmp", "myapp", "   ");
-        assertEquals(new File("/tmp", "myapp.ear"), result);
-        assertFalse(
-                result.getAbsolutePath().contains(" "),
-                "EAR filename should not contain spaces from whitespace-only classifier");
+        File result = invokeGetEarFile("myapp", "-sources");
+        assertEquals(new File(TMPDIR, "myapp-sources.ear"), result);
     }
 }

--- a/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/ear/EarMojoTest.java
@@ -22,34 +22,36 @@ import java.io.File;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EarMojoTest {
 
-    private static final String TMPDIR = System.getProperty("java.io.tmpdir");
+    @TempDir
+    static File tempDir;
 
     private static File invokeGetEarFile(String finalName, String classifier) throws Exception {
         Method method = EarMojo.class.getDeclaredMethod("getEarFile", String.class, String.class, String.class);
         method.setAccessible(true);
-        return (File) method.invoke(null, TMPDIR, finalName, classifier);
+        return (File) method.invoke(null, tempDir.getAbsolutePath(), finalName, classifier);
     }
 
     @Test
     void testGetEarFileWithNullClassifier() throws Exception {
         File result = invokeGetEarFile("myapp", null);
-        assertEquals(new File(TMPDIR, "myapp.ear"), result);
+        assertEquals(new File(tempDir, "myapp.ear"), result);
     }
 
     @Test
     void testGetEarFileWithClassifier() throws Exception {
         File result = invokeGetEarFile("myapp", "sources");
-        assertEquals(new File(TMPDIR, "myapp-sources.ear"), result);
+        assertEquals(new File(tempDir, "myapp-sources.ear"), result);
     }
 
     @Test
     void testGetEarFileWithDashPrefixedClassifier() throws Exception {
         File result = invokeGetEarFile("myapp", "-sources");
-        assertEquals(new File(TMPDIR, "myapp-sources.ear"), result);
+        assertEquals(new File(tempDir, "myapp-sources.ear"), result);
     }
 }

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -1434,4 +1434,17 @@ class EarMojoIT extends AbstractEarPluginIT {
     void testProject102() throws Exception {
         doTestProject("project-102", new String[] {"eartest-ejb-sample-one-1.0.jar"});
     }
+
+    /**
+     * Builds an EAR with a whitespace-only classifier.
+     * Verifies the whitespace is trimmed and does not appear in the filename.
+     */
+    @Test
+    void testProject103() throws Exception {
+        final File baseDir = executeMojo("project-103");
+        final File badFile = new File(baseDir, "target/maven-ear-plugin-test-project-103-99.0   .ear");
+        final File expectedFile = new File(baseDir, "target/maven-ear-plugin-test-project-103-99.0.ear");
+        assertFalse(badFile.exists(), "EAR filename should not contain spaces from whitespace classifier");
+        assertTrue(expectedFile.exists(), "EAR archive not found at expected path without spaces");
+    }
 }

--- a/src/test/resources/projects/project-103/pom.xml
+++ b/src/test/resources/projects/project-103/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ear</groupId>
+  <artifactId>maven-ear-plugin-test-project-103</artifactId>
+  <version>99.0</version>
+  <name>Maven</name>
+  <packaging>ear</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>eartest</groupId>
+      <artifactId>ejb-sample-one</artifactId>
+      <version>1.0</version>
+      <type>ejb</type>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-ear-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <classifier>&#x20;&#x20;&#x20;</classifier>
+          <version>1.3</version>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Fixes #521

## Bug
A whitespace-only classifier string (e.g. "   ") is not properly handled:
- `classifier.trim().length() > 0` evaluates to `false` for whitespace-only strings
- Neither branch of the if/else-if applies
- The raw whitespace string is used in the filename, producing filenames like `myApp    .ear`

## Fix
- Trim the classifier string before processing
- Treat empty/whitespace-only classifiers the same as `null` (produce `finalName.ear`)
- Simplify the condition: after trimming, just check `isEmpty()` and `startsWith("-")`

## Tests
- **Unit test** (`EarMojoTest`): tests `getEarFile()` with null, normal, dash-prefixed, and whitespace-only classifiers via reflection
- **Integration test** (project-103): builds an EAR with a whitespace-only classifier and verifies the output filename has no spaces

The unit test for whitespace-only classifier fails before the fix:
```
expected: </tmp/myapp.ear> but was: </tmp/myapp   .ear>
```