### PR TITLE
Fix wrong file extension for EJB module in excluding-files-from-ear example

### DIFF
--- a/src/site/apt/examples/excluding-files-from-ear.apt.vm
+++ b/src/site/apt/examples/excluding-files-from-ear.apt.vm
@@ -70,7 +70,7 @@ Excluding Files From the EAR
  `-- external-library-3.jar
 
  acme-ear-2
- |-- acme-ejb-1.war
+ |-- acme-ejb-1.jar
  |-- acme-library-1.jar
  |-- acme-library-2.jar
  |-- acme-war-3.war


### PR DESCRIPTION
The example tree shows acme-ejb-1.war, but EJB modules are .jar archives, not .war.