### PR TITLE
Fix invalid ejb-ref-type value in example

### DIFF
--- a/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
@@ -42,7 +42,7 @@ Specifying Ejb Ref entries For The Generated application.xml
             <ejb-ref>
               <description>A description test</description>
               <ejb-ref-name>first-name</ejb-ref-name>
-              <ejb-ref-type>java.lang.String</ejb-ref-type>
+              <ejb-ref-type>Session</ejb-ref-type>
               <lookup-name>java-test</lookup-name>
             </ejb-ref>
           </ejbRefs>


### PR DESCRIPTION
<ejb-ref-type> must be 'Session' or 'Entity', not 'java.lang.String'.