### PR TITLE
Fix wrong title in specifying-env-entries example

### DIFF
--- a/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
@@ -24,7 +24,7 @@
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
 
-Specifying Environment entries For The Generated application.xml
+Specifying Environment entries for the Generated application.xml
 
   Environment entries can be added as from the JavaEE 6 spec. For instance:
 

--- a/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Specifying Security Roles For The Generated application.xml
+  Specifying Environment entries For The Generated application.xml
   ------
   Stephane Nicoll
   <snicoll@apache.org>

--- a/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Specifying Environment entries For The Generated application.xml
+  Specifying Environment Entries for the Generated application.xml
   ------
   Stephane Nicoll
   <snicoll@apache.org>
@@ -24,7 +24,7 @@
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
 
-Specifying Environment entries for the Generated application.xml
+Specifying Environment Entries for the Generated application.xml
 
   Environment entries can be added as from the JavaEE 6 spec. For instance:
 


### PR DESCRIPTION
Title was copy-pasted from the security-roles example instead of describing environment entries.