### PR TITLE
Fix broken links in site documentation

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -61,7 +61,8 @@ ${project.name}
   {{{./modules.html}modules configuration}}.
 
   For more information please visit
-  {{{https://jakarta.ee/}Jakarta EE}}.
+  {{{https://jakarta.ee/}Jakarta EE}}
+  {{{https://www.oracle.com/java/technologies/java-ee-glance.html}Java EE at a glance}}.
 
 * Version 3.4.0
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -61,8 +61,7 @@ ${project.name}
   {{{./modules.html}modules configuration}}.
 
   For more information please visit
-  {{{https://jakarta.ee/}Jakarta EE}}
-  {{{https://www.oracle.com/java/technologies/java-ee-glance.html}Java EE at a glance}}.
+  {{{https://jakarta.ee/}Jakarta EE}}.
 
 * Version 3.4.0
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -21,7 +21,7 @@ under the License.
 
 <project xmlns="http://maven.apache.org/DECORATION/1.8.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
 
   <body>
     <menu name="Overview">

--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -53,7 +53,7 @@ under the License.
               <td>${project.name} ${project.version} (Source zip)</td>
               <td><a href="[preferred]maven/plugins/${project.artifactId}-${project.version}-source-release.zip">${project.artifactId}-${project.version}-source-release.zip</a></td>
               <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.sha512">${project.artifactId}-${project.version}-source-release.zip.sha512</a></td>
-              <td><a href="https://downloads.apache.org//maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
+              <td><a href="https://downloads.apache.org/maven/plugins/${project.artifactId}-${project.version}-source-release.zip.asc">${project.artifactId}-${project.version}-source-release.zip.asc</a></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Three fixes:
- download.xml.vm: remove double slash in URL
- site.xml: fix schema URL to match namespace version (1.8.0)
- index.apt.vm: remove dead Oracle Java EE link (Jakarta EE already linked)