### PR TITLE
Fix grammar, typos, and awkward phrasing in site documentation

### DIFF
--- a/src/site/apt/examples/customize-file-name-mapping.apt.vm
+++ b/src/site/apt/examples/customize-file-name-mapping.apt.vm
@@ -49,7 +49,7 @@ Customizing The File Name Mapping
   </build>
 +---------
 
-  Based on the given things you can influence the resulting naming based on your wishes. For example you
+  The naming pattern can be customized to your needs. For example, you
   want to have all artifacts within your ear file without a version you can change the configuration like the 
   following:
 
@@ -73,7 +73,7 @@ Customizing The File Name Mapping
   dash which is needed to separate it from other parts of the artifact
 
   * <<<@\{version\}@>>> - expands to artifact version,
-  for <<<SNAPSHOT>>> artifacts can contain timestamp postfix instead of <<<SNAPSHOT>>>
+  for <<<SNAPSHOT>>> artifacts. It can contain a timestamp instead of <<<SNAPSHOT>>>
 
   * <<<@\{baseVersion\}@>>> - expands to base artifact version,
   for <<<SNAPSHOT>>> artifacts we will always have <<<SNAPSHOT>>> postfix

--- a/src/site/apt/examples/customize-file-name-mapping.apt.vm
+++ b/src/site/apt/examples/customize-file-name-mapping.apt.vm
@@ -27,9 +27,9 @@
 
 Customizing The File Name Mapping
 
-  It might happen that you need to change the naming of the artifacts within the EAR file.
-  This can be achieved by using the <<<outputFileNameMapping>>>. The following shows how it could be 
-  configured in your pom file.
+  You can change the names of the artifacts within the EAR file
+  using <<<outputFileNameMapping>>>. The following shows how it can be 
+  configured in the pom file.
 
   In this example the default value is given as a starting point.
 
@@ -49,8 +49,8 @@ Customizing The File Name Mapping
   </build>
 +---------
 
-  The naming pattern can be customized to your needs. For example, you
-  want to have all artifacts within your ear file without a version you can change the configuration like the 
+  The naming pattern can be customized to your needs. For example, if you
+  want all artifacts within the ear file to not include version, change the configuration like the 
   following:
 
 +--------

--- a/src/site/apt/examples/eclipse-and-maven-integration.apt.vm
+++ b/src/site/apt/examples/eclipse-and-maven-integration.apt.vm
@@ -30,7 +30,7 @@ Eclipse and Maven Integration (without m2e)
   
   If you have used <<<mvn eclipse:eclipse>>> to generate the metadata for an EAR project, it will want the <<<application.xml>>> file in the <<<src/main/application/META-INF>>> directory. 
 
-  If you edit <<<application.xml>>> using the WTP based Application Deployment Descriptor editor, it will use the name of the projects (Web, EJB etc) as the name of the modules. Here is an example:
+  If you edit <<<application.xml>>> using the WTP based Application Deployment Descriptor editor, it will use the names of the projects (Web, EJB etc) as the name of the modules. Here is an example:
 
 +------------------------+
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/site/apt/examples/eclipse-and-maven-integration.apt.vm
+++ b/src/site/apt/examples/eclipse-and-maven-integration.apt.vm
@@ -30,7 +30,7 @@ Eclipse and Maven Integration (without m2e)
   
   If you have used <<<mvn eclipse:eclipse>>> to generate the metadata for an EAR project, it will want the <<<application.xml>>> file in the <<<src/main/application/META-INF>>> directory. 
 
-  If you edit <<<application.xml>>> using the WTP based Application Deployment Descriptor editor, it will use the names of the projects (Web, EJB etc) as the name of the modules. Here is an example:
+  If you edit <<<application.xml>>> using the WTP based Application Deployment Descriptor editor, it will use the names of the projects (Web, EJB etc) as the names of the modules. Here is an example:
 
 +------------------------+
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/site/apt/examples/excluding-files-from-ear.apt.vm
+++ b/src/site/apt/examples/excluding-files-from-ear.apt.vm
@@ -190,7 +190,7 @@ Excluding Files From the EAR
 
 * Transitive artifacts
 
-  For those who have good reason to exclude transitive dependencies, they can configure their <<<pom.xml>>> like this when using Maven3
+  For those who have good reason to exclude transitive dependencies, they can configure their <<<pom.xml>>> like this when using Maven 3
   
 +---------------------
   <dependency>
@@ -206,4 +206,4 @@ Excluding Files From the EAR
   </dependency>
 +---------------------
 
-  As you can see <<<exclusions>>> support wildcard expressions, so you can have fast and full control over all the dependencies you'd like to exclude.    
+  As you can see <<<exclusions>>> support wildcard expressions, so you can have fine-grained control over all the dependencies you'd like to exclude.    

--- a/src/site/apt/examples/excluding-files-from-ear.apt.vm
+++ b/src/site/apt/examples/excluding-files-from-ear.apt.vm
@@ -206,4 +206,4 @@ Excluding Files From the EAR
   </dependency>
 +---------------------
 
-  As you can see <<<exclusions>>> support wildcard expressions, so you can have fine-grained control over all the dependencies you'd like to exclude.    
+  As you can see <<<exclusions>>> support wildcard expressions, so you can have fine-grained control over all the dependencies you'd like to exclude.

--- a/src/site/apt/examples/filtering-advanced.apt.vm
+++ b/src/site/apt/examples/filtering-advanced.apt.vm
@@ -69,8 +69,7 @@ jdbc.password=${db.password}
 +--------
 
   Filtering the content of such a file with this config will produce this content.
-  Note that the escaped property can now be filtered the usual way later if
-  necessary!
+  The escaped property can be filtered the usual way later if necessary.
 
 +--------
 jdbc.url=jdbc:oracle:thin:@localhost:1521:orcl

--- a/src/site/apt/examples/filtering-advanced.apt.vm
+++ b/src/site/apt/examples/filtering-advanced.apt.vm
@@ -35,10 +35,10 @@ Filtering: Advanced techniques
 
 * Escaping properties
 
-  It may be necessary to filters some properties in a file and ignore another. The
-  filtering mechanism won't touch a token that is not recognized (i.e. that
-  represents an unknown property). This won't work if the property is known
-  obviously so it should be escaped explicitely.
+  It may be necessary to filter some properties in a file while leaving others
+  untouched. The filtering mechanism will not touch a token that represents an
+  unknown property, but a known property will be interpolated. To prevent that,
+  the known property must be escaped explicitly.
 
   The following configuration defines the value of the <<<escapeString>>> which will
   stop the interpolation of a property if it starts with that value
@@ -69,7 +69,7 @@ jdbc.password=${db.password}
 +--------
 
   Filtering the content of such a file with this config will produce this content.
-  Note that that the escaped property can now be filtered the usual way later if
+  Note that the escaped property can now be filtered the usual way later if
   necessary!
 
 +--------
@@ -82,7 +82,7 @@ jdbc.password=${db.password}
 * Ignoring files based on its extension
 
   Filtering binary files corrupt them so it may be necessary to exclude files from
-  filtering based on the extension. To do so, configure the plugin as follow
+  filtering based on the extension. To do so, configure the plugin as follows
 
 +--------
   <build>

--- a/src/site/apt/examples/skinny-modules.apt.vm
+++ b/src/site/apt/examples/skinny-modules.apt.vm
@@ -130,7 +130,7 @@ Creating Skinny Modules
  If an archive representing the EAR module has non-standard location of libraries,
  then this location can be configured using the <<<libDirectory>>> property.
 
- Here is example for SAR which contains libraries at the root of the archive
+ Here is an example for SAR which contains libraries at the root of the archive
  (refer to {{{../modules.html#sarModule}sarModule}} for description of
  <<<libDirectory>>> property):
 

--- a/src/site/apt/examples/skinny-wars.apt.vm
+++ b/src/site/apt/examples/skinny-wars.apt.vm
@@ -29,10 +29,10 @@
 
 Creating Skinny WARs
 
- In a typical J2EE environment, a WAR is packaged within an EAR for deployment.  The
+ In a typical Java EE environment, a WAR is packaged within an EAR for deployment.  The
  WAR can contain all its dependent JARs in <<<WEB-INF/lib>>> but then the EAR can quickly grow
  very large if there are multiple WARs, due to the presence of duplicate JARs.  Instead
- the J2EE specification allows WARs to reference external JARs packaged within the EAR
+ the Java EE specification allows WARs to reference external JARs packaged within the EAR
  via the <<<Class-Path>>> setting in their <<<MANIFEST.MF>>>.
 
  Starting with version 2.7 Maven EAR Plugin has basic support for this mode of
@@ -42,7 +42,7 @@ Creating Skinny WARs
  in the EAR, using the <<<skinnyWars>>> parameter.
 
  <<Note:>> In this example we package all JARs into a <<<lib/>>> directory
- within the EAR. This is just to distinguish between J2EE modules (which will be
+ within the EAR. This is just to distinguish between Java EE modules (which will be
  packaged in the root of the EAR) and Java libraries (which are packaged in
  <<<lib/>>>).
 

--- a/src/site/apt/examples/skinny-wars.apt.vm
+++ b/src/site/apt/examples/skinny-wars.apt.vm
@@ -30,18 +30,18 @@
 Creating Skinny WARs
 
  In a typical Java EE environment, a WAR is packaged within an EAR for deployment.  The
- WAR can contain all its dependent JARs in <<<WEB-INF/lib>>> but then the EAR can quickly grow
- very large if there are multiple WARs, due to the presence of duplicate JARs.  Instead
+ WAR can contain all its dependent JARs in <<<WEB-INF/lib>>> so the EAR can quickly grow
+ very large if there are multiple WARs, due to the presence of duplicate JARs. Instead,
  the Java EE specification allows WARs to reference external JARs packaged within the EAR
  via the <<<Class-Path>>> setting in their <<<MANIFEST.MF>>>.
 
- Starting with version 2.7 Maven EAR Plugin has basic support for this mode of
+ Starting with version 2.7, the Maven EAR Plugin has basic support for this mode of
  operation.
 
- First we need to change the EAR project's <<<pom.xml>>> to package those JARs
+ First change the EAR project's <<<pom.xml>>> to package those JARs
  in the EAR, using the <<<skinnyWars>>> parameter.
 
- <<Note:>> In this example we package all JARs into a <<<lib/>>> directory
+ <<Note:>> In this example, we package all JARs into a <<<lib/>>> directory
  within the EAR. This is just to distinguish between Java EE modules (which will be
  packaged in the root of the EAR) and Java libraries (which are packaged in
  <<<lib/>>>).
@@ -65,7 +65,7 @@ Creating Skinny WARs
 </project>
 +-----------------+
 
- Now the painful part.  Your EAR project's <<<pom.xml>>> needs to list every
+ Now the painful part. The EAR project's <<<pom.xml>>> needs to list every
  dependency that you want to share through the EAR.
 
 +-----------------+
@@ -95,7 +95,7 @@ Creating Skinny WARs
 </project>
 +-----------------+
 
- Your EAR will contain something like this:
+ The EAR will contain something like this:
 
 +-----------------+
  .
@@ -111,6 +111,6 @@ Creating Skinny WARs
  that are packaged within the EAR, you will see that they no longer contain the
  file <<<WEB-INF/lib/shared-jar-1.0.0.jar>>>.
 
- Also, if you inspect the <<<MANIFEST.MF>>> of the WARs you will notice that the
+ Also, if you inspect the <<<MANIFEST.MF>>> of the WARs, you will notice that the
  <<<Class-Path>>> entry has been modified and now has a reference to
  <<<lib/shared-jar-1.0.0.jar>>>.

--- a/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
@@ -23,9 +23,9 @@
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
 
-Specifying Ejb Ref entries For The Generated application.xml
+Specifying EJB Ref entries for the Generated application.xml
 
-  Ejb Ref entries can be added since the Java EE 6 spec. For instance:
+  EJB Ref entries can be added since the Java EE 6 spec. For instance:
 
 +--------
   <build>

--- a/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.apt.vm
@@ -25,7 +25,7 @@
 
 Specifying Ejb Ref entries For The Generated application.xml
 
-  Ejb Ref entries can be added as from the JavaEE 6 spec. For instance:
+  Ejb Ref entries can be added since the Java EE 6 spec. For instance:
 
 +--------
   <build>

--- a/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
@@ -26,7 +26,7 @@
 
 Specifying Environment entries For The Generated application.xml
 
-  Environment entries can be added as from the JavaEE 6 spec. For instance:
+  Environment entries can be added since the Java EE 6 spec. For instance:
 
 +--------
   <build>

--- a/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-env-entries-for-the-generated-application-xml.apt.vm
@@ -24,7 +24,7 @@
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
 
-Specifying Environment entries For The Generated application.xml
+Specifying Environment Entries for the Generated application.xml
 
   Environment entries can be added since the Java EE 6 spec. For instance:
 

--- a/src/site/apt/examples/specifying-resource-ref-entries-for-the-generated-application-xml.apt.vm
+++ b/src/site/apt/examples/specifying-resource-ref-entries-for-the-generated-application-xml.apt.vm
@@ -25,7 +25,7 @@
 
 Specifying Resource Ref entries For The Generated application.xml
 
-  Resource Ref entries can be added as from the JavaEE 6 spec. For instance:
+  Resource Ref entries can be added since the Java EE 6 spec. For instance:
 
 +--------
   <build>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -97,7 +97,7 @@ ${project.name}
 
   EAR Plugin has two goals:
 
-  * {{{./ear-mojo.html}ear:ear}} generates J2EE Enterprise Archive (EAR) files.
+  * {{{./ear-mojo.html}ear:ear}} generates Jakarta EE Enterprise Archive (EAR) files.
 
   * {{{./generate-application-xml-mojo.html}ear:generate-application-xml}}
   generates the deployment descriptor file(s).

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -97,7 +97,7 @@ ${project.name}
 
   EAR Plugin has two goals:
 
-  * {{{./ear-mojo.html}ear:ear}} generates Jakarta EE Enterprise Archive (EAR) files.
+  * {{{./ear-mojo.html}ear:ear}} generates Java EE / Jakarta EE Enterprise Archive (EAR) files.
 
   * {{{./generate-application-xml-mojo.html}ear:generate-application-xml}}
   generates the deployment descriptor file(s).

--- a/src/site/apt/modules.apt.vm
+++ b/src/site/apt/modules.apt.vm
@@ -71,7 +71,7 @@ EAR Modules
         <configuration>
           <modules>
             <ejbModule>
-              <!-- property configurations goes here -->
+              <!-- property configurations go here -->
             </ejbModule>
           </modules>
         </configuration>
@@ -93,7 +93,7 @@ EAR Modules
   Default is 'ejb-client'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -161,7 +161,7 @@ EAR Modules
   Default is 'ejb'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -207,7 +207,7 @@ EAR Modules
   Default is 'jar'. Use 'test-jar' if the artifact of the module is test JAR.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -231,7 +231,7 @@ EAR Modules
 
   * <<moduleId>> - sets the id of the module in the generated application.xml.
 
-  * <<includeInApplicationXml>> - set to true to if you want to generate an entry
+  * <<includeInApplicationXml>> - set to true if you want to generate an entry
   of this module in <<<application.xml>>>. Default is false.
 
   * <<classPathItem>> - defines if the module is an element of the <<<Class-Path>>> setting
@@ -293,7 +293,7 @@ EAR Modules
   and has 'jboss-par' type, then that type should be specified explicitly.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -339,7 +339,7 @@ EAR Modules
   Default is 'rar'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -390,7 +390,7 @@ EAR Modules
   and has 'jboss-sar' type, then that type should be specified explicitly.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -435,7 +435,7 @@ EAR Modules
   Default is 'war'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -490,7 +490,7 @@ EAR Modules
   Default is 'wsr'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -540,7 +540,7 @@ EAR Modules
   and has 'jboss-har' type, then that type should be specified explicitly.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 
@@ -583,7 +583,7 @@ EAR Modules
   Default is 'app-client'.
 
   * <<classifier>> - sets the classifier of the artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId/type. Use
+  configure if multiple artifacts match the groupId/artifactId/type. Use
   the mainArtifactId ('none' by default) to define the main artifact (e.g.
   the artifact without a classifier).
 

--- a/src/site/apt/tests.apt
+++ b/src/site/apt/tests.apt
@@ -26,7 +26,7 @@
 
 EAR Plugin Tests
 
-  This page lists the EAR Plugin integration tests. Each tests is built on top of a sample project available in
+  This page lists the EAR Plugin integration tests. Each test is built on top of a sample project available in
   the {{{https://gitbox.apache.org/repos/asf?p=maven-ear-plugin.git;a=tree;f=src/test/resources/projects}git repository}}.
   This structure provides lots of concrete use cases for beginners.
 
@@ -80,7 +80,7 @@ EAR Plugin Tests
 
   * project-025: builds an EAR and make sure that a classified dependency with multiple candidates is detected when specifying the classifier
 
-  * project-026: builds an EAR and make sure that the build fails if a unclassified module configuration with multiple candidates is specified
+  * project-026: builds an EAR and make sure that the build fails if an unclassified module configuration with multiple candidates is specified
 
   * project-027: builds an EAR and make sure that provided dependencies are not included in the EAR
 
@@ -190,4 +190,4 @@ EAR Plugin Tests
 
   * project-080: builds an EAR with the 'empty' library directory mode. Generate an empty library-directory element
 
-  * project-081: builds an EAR with the 'none' library directory mode. Does not generate an library-directory element
+  * project-081: builds an EAR with the 'none' library directory mode. Does not generate a library-directory element

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -54,7 +54,7 @@ Usage
         <artifactId>maven-ear-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <!-- configuration elements goes here -->
+          <!-- configuration elements go here -->
         </configuration>
       </plugin>
    [...]
@@ -197,7 +197,7 @@ mvn package
   
 
   Hibernate archives (HAR) and Service archives (SAR) will be recognized automatically
-  and added the the <<<jboss-app.xml>>> file.
+  and added to the <<<jboss-app.xml>>> file.
 
   You can take a look at the examples for more information on the JBoss support.
 

--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -48,7 +48,7 @@ under the License.
    </faq>
    <faq id="avoid-display-name">
      <question>
-       How can I avoid to generate a display-name entry in the generated application.xml?
+       How can I avoid generating a display-name entry in the generated application.xml?
      </question>
      <answer>
        <p>


### PR DESCRIPTION
Fixes multiple issues across 14 site doc files:

Grammar:
- configurations goes -> go, artifacts matches -> match (10x)
- Each tests is -> Each test is
- a unclassified -> an unclassified, an library -> a library
- avoid to generate -> avoid generating

Typos:
- explicitely -> explicitly
- Maven3 -> Maven 3
- to filters -> to filter
- as follow -> as follows
- set to true to if -> set to true if
- Note that that the -> Note that the
- Here is example -> Here is an example

Awkward phrasing:
- Rewrote confusing escaping explanation in filtering-advanced
- Simplified customize-file-name-mapping wording
- Fixed punctuation in version description
- names of the projects (plural agreement)
- fast and full control -> fine-grained control
- as from -> since
- J2EE -> Java EE / Jakarta EE (3 files)