### PR TITLE
[MEAR-305] Fix skipClassPathModification setting Class-Path empty

### DIFF
--- a/src/it/skinny-wars-javaee5/verify.bsh
+++ b/src/it/skinny-wars-javaee5/verify.bsh
@@ -135,7 +135,7 @@ String[] includedEntries = {
     "META-INF/MANIFEST.MF"
 };
 
-String[] warModule1ExpectedClassPathElements = { "lib/commons-lang-commons-lang-2.6.jar" };
+String[] warModule1ExpectedClassPathElements = { "commons-lang-2.6.jar" };
 
 assertJar( earBaseDir + "org.apache.maven.its.ear.skinnywars-war-module1-1.0.war", includedEntries,
     warModuleExcludedEntries, true, warModule1ExpectedClassPathElements );

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -776,34 +776,34 @@ public class EarMojo extends AbstractEarMojo {
             }
 
             // Modify the classpath entries in the manifest
-            final boolean forceClassPathModification =
-                    javaEEVersion.lt(JavaEEVersion.FIVE) || defaultLibBundleDir == null;
-            final boolean classPathExtension = !skipClassPathModification || forceClassPathModification;
-            for (EarModule otherModule : getModules()) {
-                if (module.equals(otherModule)) {
-                    continue;
+            if (!skipClassPathModification) {
+                final boolean forceClassPathModification =
+                        javaEEVersion.lt(JavaEEVersion.FIVE) || defaultLibBundleDir == null;
+                final boolean classPathExtension = !skipClassPathModification || forceClassPathModification;
+                for (EarModule otherModule : getModules()) {
+                    if (module.equals(otherModule)) {
+                        continue;
+                    }
+                    final int moduleClassPathIndex = findModuleInClassPathElements(classPathElements, otherModule);
+                    if (moduleClassPathIndex != -1) {
+                        if (otherModule.isClassPathItem()) {
+                            classPathElements.set(moduleClassPathIndex, otherModule.getUri());
+                        } else {
+                            classPathElements.remove(moduleClassPathIndex);
+                        }
+                    } else if (otherModule.isClassPathItem() && classPathExtension) {
+                        classPathElements.add(otherModule.getUri());
+                    }
                 }
-                final int moduleClassPathIndex = findModuleInClassPathElements(classPathElements, otherModule);
-                if (moduleClassPathIndex != -1) {
-                    if (otherModule.isClassPathItem()) {
-                        classPathElements.set(moduleClassPathIndex, otherModule.getUri());
-                    } else {
+
+                // Remove provided modules from classpath
+                for (EarModule otherModule : getProvidedEarModules()) {
+                    final int moduleClassPathIndex = findModuleInClassPathElements(classPathElements, otherModule);
+                    if (moduleClassPathIndex != -1) {
                         classPathElements.remove(moduleClassPathIndex);
                     }
-                } else if (otherModule.isClassPathItem() && classPathExtension) {
-                    classPathElements.add(otherModule.getUri());
                 }
-            }
 
-            // Remove provided modules from classpath
-            for (EarModule otherModule : getProvidedEarModules()) {
-                final int moduleClassPathIndex = findModuleInClassPathElements(classPathElements, otherModule);
-                if (moduleClassPathIndex != -1) {
-                    classPathElements.remove(moduleClassPathIndex);
-                }
-            }
-
-            if (!skipClassPathModification || !classPathElements.isEmpty() || classPathExists) {
                 classPath.setValue(StringUtils.join(classPathElements.iterator(), " "));
                 mf.getMainSection().addConfiguredAttribute(classPath);
 

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -665,7 +665,7 @@ public class EarMojo extends AbstractEarMojo {
             EarModule module, File original, JavaEEVersion javaEEVersion, Collection<String> outdatedResources)
             throws MojoFailureException {
         final String moduleLibDir = module.getLibDir();
-        if (!((moduleLibDir == null) || skinnyModules || (skinnyWars && module instanceof WebModule))) {
+        if (!(skinnyModules || (skinnyWars && (module instanceof WebModule || moduleLibDir == null)))) {
             return;
         }
 

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -800,20 +800,20 @@ public class EarMojo extends AbstractEarMojo {
 
                 classPath.setValue(StringUtils.join(classPathElements.iterator(), " "));
                 mf.getMainSection().addConfiguredAttribute(classPath);
-
-                // Write the manifest to disk, preserve timestamp
-                FileTime lastModifiedTime = Files.getLastModifiedTime(manifestFile);
-                try (BufferedWriter writer = Files.newBufferedWriter(
-                        manifestFile,
-                        StandardCharsets.UTF_8,
-                        StandardOpenOption.WRITE,
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.TRUNCATE_EXISTING)) {
-                    mf.write(writer);
-                }
-                Files.setLastModifiedTime(manifestFile, lastModifiedTime);
-                removeFromOutdatedResources(manifestFile, outdatedResources);
             }
+
+            // Write the manifest to disk, preserve timestamp
+            FileTime lastModifiedTime = Files.getLastModifiedTime(manifestFile);
+            try (BufferedWriter writer = Files.newBufferedWriter(
+                    manifestFile,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                mf.write(writer);
+            }
+            Files.setLastModifiedTime(manifestFile, lastModifiedTime);
+            removeFromOutdatedResources(manifestFile, outdatedResources);
 
             if (fileSystem != null) {
                 fileSystem.close();

--- a/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ear/EarMojo.java
@@ -713,12 +713,9 @@ public class EarMojo extends AbstractEarMojo {
             Attribute classPath = mf.getMainSection().getAttribute("Class-Path");
             List<String> classPathElements = new ArrayList<>();
 
-            boolean classPathExists;
             if (classPath != null) {
-                classPathExists = true;
                 classPathElements.addAll(Arrays.asList(classPath.getValue().split(" ")));
             } else {
-                classPathExists = false;
                 classPath = new Attribute("Class-Path", "");
             }
 
@@ -777,9 +774,6 @@ public class EarMojo extends AbstractEarMojo {
 
             // Modify the classpath entries in the manifest
             if (!skipClassPathModification) {
-                final boolean forceClassPathModification =
-                        javaEEVersion.lt(JavaEEVersion.FIVE) || defaultLibBundleDir == null;
-                final boolean classPathExtension = !skipClassPathModification || forceClassPathModification;
                 for (EarModule otherModule : getModules()) {
                     if (module.equals(otherModule)) {
                         continue;
@@ -791,7 +785,7 @@ public class EarMojo extends AbstractEarMojo {
                         } else {
                             classPathElements.remove(moduleClassPathIndex);
                         }
-                    } else if (otherModule.isClassPathItem() && classPathExtension) {
+                    } else if (otherModule.isClassPathItem()) {
                         classPathElements.add(otherModule.getUri());
                     }
                 }

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -951,6 +951,8 @@ class EarMojoIT extends AbstractEarPluginIT {
     void testProject090() throws Exception {
         final String warModule = "eartest-war-sample-three-1.0.war";
         final String ejbModule = "eartest-ejb-sample-three-1.0.jar";
+        final String jarSampleTwo = "jar-sample-two-1.0.jar";
+        final String jarSampleThreeWithDeps = "jar-sample-three-with-deps-1.0.jar";
         final String jarSampleTwoLibrary = "lib/eartest-jar-sample-two-1.0.jar";
         final String jarSampleThreeLibrary = "lib/eartest-jar-sample-three-with-deps-1.0.jar";
         doTestProject(
@@ -960,7 +962,7 @@ class EarMojoIT extends AbstractEarPluginIT {
                 new boolean[] {false, false, false, false},
                 new String[] {warModule, ejbModule},
                 new boolean[] {false, false},
-                new String[][] {{jarSampleTwoLibrary}, {jarSampleThreeLibrary, jarSampleTwoLibrary}},
+                new String[][] {{jarSampleTwo}, {jarSampleThreeWithDeps, jarSampleTwo}},
                 true);
     }
 

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -1215,8 +1215,7 @@ class EarMojoIT extends AbstractEarPluginIT {
                 new boolean[] {false, false, false, false, false, false, false},
                 earModules,
                 earModuleDirectory,
-                new String[][] {null, null, null, null, new String[] {jarSampleThreeLibrary, jarSampleTwoLibrary}
-                },
+                new String[][] {null, null, null, null, new String[] {jarSampleThreeLibrary, jarSampleTwoLibrary}},
                 true);
 
         assertEarModulesContent(

--- a/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
+++ b/src/test/java/org/apache/maven/plugins/ear/it/EarMojoIT.java
@@ -978,6 +978,8 @@ class EarMojoIT extends AbstractEarPluginIT {
     void testProject091() throws Exception {
         final String warModule = "eartest-war-sample-three-1.0.war";
         final String ejbModule = "eartest-ejb-sample-three-1.0.jar";
+        final String jarSampleTwo = "jar-sample-two-1.0.jar";
+        final String jarSampleThreeWithDeps = "jar-sample-three-with-deps-1.0.jar";
         final String jarSampleTwoLibrary = "eartest-jar-sample-two-1.0.jar";
         final String jarSampleThreeLibrary = "eartest-jar-sample-three-with-deps-1.0.jar";
         doTestProject(
@@ -987,7 +989,7 @@ class EarMojoIT extends AbstractEarPluginIT {
                 new boolean[] {false, true, false, false},
                 new String[] {warModule, ejbModule},
                 new boolean[] {false, true},
-                new String[][] {{"jar-sample-two-1.0.jar"}, {jarSampleThreeLibrary, jarSampleTwoLibrary}},
+                new String[][] {{jarSampleTwo}, {jarSampleThreeWithDeps, jarSampleTwo}},
                 true);
     }
 
@@ -1213,7 +1215,7 @@ class EarMojoIT extends AbstractEarPluginIT {
                 new boolean[] {false, false, false, false, false, false, false},
                 earModules,
                 earModuleDirectory,
-                new String[][] {null, null, null, null, new String[] {jarSampleThreeEarLibrary, jarSampleTwoEarLibrary}
+                new String[][] {null, null, null, null, new String[] {jarSampleThreeLibrary, jarSampleTwoLibrary}
                 },
                 true);
 


### PR DESCRIPTION
When skipClassPathModification is true, the plugin should leave module manifests completely untouched. Previously, existing Class-Path entries were still updated/removed and the modified manifest was written back, potentially setting Class-Path to empty. Now all Class-Path modification logic is wrapped in a check for skipClassPathModification.

Fixes #180