### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/customize-file-name-mapping.md.vm
+++ b/src/site/markdown/examples/customize-file-name-mapping.md.vm
@@ -1,3 +1,12 @@
+---
+title: Customizing The File Name Mapping
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+  - Karl Heinz Marbaise khmarbaise@apache.org
+date: 2006-11-19
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/customizing-a-module-filename.md.vm
+++ b/src/site/markdown/examples/customizing-a-module-filename.md.vm
@@ -1,3 +1,11 @@
+---
+title: Customizing A Module Filename
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/customizing-context-root.md.vm
+++ b/src/site/markdown/examples/customizing-context-root.md.vm
@@ -1,3 +1,11 @@
+---
+title: Customizing The Context Root
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/customizing-module-location.md.vm
+++ b/src/site/markdown/examples/customizing-module-location.md.vm
@@ -1,3 +1,11 @@
+---
+title: Customizing A Module Location
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2011-12-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/customizing-module-uri.md.vm
+++ b/src/site/markdown/examples/customizing-module-uri.md.vm
@@ -1,3 +1,11 @@
+---
+title: Customizing A Module URI
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/eclipse-and-maven-integration.md.vm
+++ b/src/site/markdown/examples/eclipse-and-maven-integration.md.vm
@@ -1,3 +1,11 @@
+---
+title: Eclipse and Maven integration
+author: 
+  - Chris Graham
+  - Robert Scholte
+date: 2013-11-19
+---
+
 <!--
 Copyright 2013 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/excluding-a-module.md.vm
+++ b/src/site/markdown/examples/excluding-a-module.md.vm
@@ -1,3 +1,11 @@
+---
+title: Excluding A Module
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/excluding-files-from-ear.md.vm
+++ b/src/site/markdown/examples/excluding-files-from-ear.md.vm
@@ -1,3 +1,10 @@
+---
+title: Excluding Files From the EAR
+author: 
+  - Dennis Lundberg
+date: 2011-12-09
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/filtering-advanced.md.vm
+++ b/src/site/markdown/examples/filtering-advanced.md.vm
@@ -1,3 +1,11 @@
+---
+title: Filtering Advanced Techniques
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2009-01-03
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/filtering-sources.md.vm
+++ b/src/site/markdown/examples/filtering-sources.md.vm
@@ -1,3 +1,11 @@
+---
+title: Filtering the sources
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2009-01-03
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/generating-jboss-app.md.vm
+++ b/src/site/markdown/examples/generating-jboss-app.md.vm
@@ -1,3 +1,11 @@
+---
+title: Generating the JBoss deployment descriptor file
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2006-08-06
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/generating-modules-id.md.vm
+++ b/src/site/markdown/examples/generating-modules-id.md.vm
@@ -1,3 +1,11 @@
+---
+title: Generating modules ID
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2010-09-04
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/including-a-third-party-library-in-application-xml.md.vm
+++ b/src/site/markdown/examples/including-a-third-party-library-in-application-xml.md.vm
@@ -1,3 +1,11 @@
+---
+title: Including A Third Party Library In application.xml
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/skinny-modules.md.vm
+++ b/src/site/markdown/examples/skinny-modules.md.vm
@@ -1,3 +1,10 @@
+---
+title: Creating Skinny Modules
+author: 
+  - Marat Abrarov
+date: 2020-10-18
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/skinny-wars.md.vm
+++ b/src/site/markdown/examples/skinny-wars.md.vm
@@ -1,3 +1,11 @@
+---
+title: Creating Skinny WARs
+author: 
+  - Mike Perham
+  - Dennis Lundberg
+date: 2011-12-09
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.md.vm
+++ b/src/site/markdown/examples/specifying-ejb-ref-entries-for-the-generated-application-xml.md.vm
@@ -1,3 +1,10 @@
+---
+title: Specifying Ejb Refs For The Generated application.xml
+author: 
+  - Karl Heinz Marbaise khmarbaise@apache.org
+date: 2026-02-14
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/specifying-env-entries-for-the-generated-application-xml.md.vm
+++ b/src/site/markdown/examples/specifying-env-entries-for-the-generated-application-xml.md.vm
@@ -1,3 +1,11 @@
+---
+title: Specifying Security Roles For The Generated application.xml
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2017-08-27
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/specifying-resource-ref-entries-for-the-generated-application-xml.md.vm
+++ b/src/site/markdown/examples/specifying-resource-ref-entries-for-the-generated-application-xml.md.vm
@@ -1,3 +1,10 @@
+---
+title: Specifying Resource Refs For The Generated application.xml
+author: 
+  - Karl Heinz Marbaise khmarbaise@apache.org
+date: 2017-08-27
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/specifying-security-roles-for-the-generated-application-xml.md.vm
+++ b/src/site/markdown/examples/specifying-security-roles-for-the-generated-application-xml.md.vm
@@ -1,3 +1,11 @@
+---
+title: Specifying Security Roles For The Generated application.xml
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2005-09-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/unpacking-a-module.md.vm
+++ b/src/site/markdown/examples/unpacking-a-module.md.vm
@@ -1,3 +1,11 @@
+---
+title: Unpacking A Module
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2006-08-14
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/examples/using-app-client.md
+++ b/src/site/markdown/examples/using-app-client.md
@@ -1,3 +1,11 @@
+---
+title: Using app client
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2011-04-03
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,12 @@
+---
+title: Introduction
+author: 
+  - Edwin Punzalan
+  - Stephane Nicoll
+  - Dennis Lundberg
+date: 2013-07-22
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/modules.md.vm
+++ b/src/site/markdown/modules.md.vm
@@ -1,3 +1,10 @@
+---
+title: EAR Modules
+author: 
+  - Edwin Punzalan
+date: 2006-07-31
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/tests.md
+++ b/src/site/markdown/tests.md
@@ -1,3 +1,10 @@
+---
+title: Tests
+author: 
+  - Stephane Nicoll
+date: 2006-10-29
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,11 @@
+---
+title: Usage
+author: 
+  - Stephane Nicoll
+  - snicoll@apache.org
+date: 2010-12-23
+---
+
 <!--
 Copyright 2006 The Apache Software Foundation.
 


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.